### PR TITLE
Move local storage banner to top of configuration page

### DIFF
--- a/src/pages/ConfigPage.tsx
+++ b/src/pages/ConfigPage.tsx
@@ -65,6 +65,11 @@ export default function ConfigPage() {
         </p>
       </div>
 
+      <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 text-sm text-blue-800">
+        <AlertCircle className="w-4 h-4 inline mr-2" />
+        Your API keys and configuration are stored in your browser's local storage and are only used to access the relevant API.
+      </div>
+
       {/* OpenHands Agent Configuration */}
       <Card className="shadow-lg hover:shadow-xl transition-shadow">
         <CardHeader>
@@ -288,11 +293,6 @@ export default function ConfigPage() {
           Please complete all required configuration before scanning repositories.
         </div>
       )}
-
-      <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 text-sm text-blue-800">
-        <AlertCircle className="w-4 h-4 inline mr-2" />
-        Your API keys and configuration are stored in your browser's local storage and are not shared with any server.
-      </div>
     </div>
   );
 }

--- a/src/test/ConfigPage.test.tsx
+++ b/src/test/ConfigPage.test.tsx
@@ -49,12 +49,40 @@ describe('ConfigPage', () => {
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
-  it('should display a note about local storage', () => {
+  it('should display a note about local storage with updated message', () => {
     renderConfigPage();
     
     const storageNote = screen.getByText(/your api keys and configuration are stored in your browser's local storage/i);
     expect(storageNote).toBeInTheDocument();
-    expect(storageNote).toHaveTextContent(/not shared with any server/i);
+    expect(storageNote).toHaveTextContent(/only used to access the relevant API/i);
+  });
+
+  it('should display the local storage banner at the top of the configuration page', () => {
+    renderConfigPage();
+    
+    const storageNote = screen.getByText(/your api keys and configuration are stored in your browser's local storage/i);
+    const configTitle = screen.getByRole('heading', { name: /Configuration/i });
+    const openHandsCard = screen.getByText(/OpenHands Agent Server/i);
+    
+    // Get the parent container
+    const storageNoteParent = storageNote.closest('.bg-blue-50');
+    const configTitleParent = configTitle.closest('.text-center');
+    const openHandsCardParent = openHandsCard.closest('.shadow-lg');
+    
+    // Verify the banner appears after the title but before the first card
+    expect(storageNoteParent).toBeInTheDocument();
+    expect(configTitleParent).toBeInTheDocument();
+    expect(openHandsCardParent).toBeInTheDocument();
+    
+    // Check DOM order: title -> banner -> card
+    const container = storageNoteParent?.parentElement;
+    const children = container ? Array.from(container.children) : [];
+    const titleIndex = children.findIndex(child => child.classList.contains('text-center'));
+    const bannerIndex = children.findIndex(child => child.classList.contains('bg-blue-50'));
+    const cardIndex = children.findIndex(child => child.classList.contains('shadow-lg'));
+    
+    expect(titleIndex).toBeLessThan(bannerIndex);
+    expect(bannerIndex).toBeLessThan(cardIndex);
   });
 
   it('should display a link to create a GitHub token', () => {


### PR DESCRIPTION
## Summary

This PR moves the "local storage" banner to the top of the configuration page and updates its message as requested in issue #5.

## Changes

- **Moved the local storage banner** from the bottom to the top of the ConfigPage (right after the title section)
- **Updated the message** from "and are not shared with any server" to "and are only used to access the relevant API"
- **Added test** to verify the banner appears at the top of the configuration page (after the title but before the first configuration card)

## Testing

- All existing tests pass
- Added new test `should display the local storage banner at the top of the configuration page` to verify the banner position
- Updated existing test `should display a note about local storage with updated message` to verify the new message text

Fixes #5

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/01416fd872a84c7c971b0384f6a36442)