### PR TITLE
Fix undefined cloudAgentUrl causing scan failure

### DIFF
--- a/src/contexts/ConfigContext.tsx
+++ b/src/contexts/ConfigContext.tsx
@@ -31,7 +31,9 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const savedConfig = storageService.loadConfig();
     if (savedConfig) {
-      setConfig(savedConfig);
+      // Merge with DEFAULT_CONFIG to ensure all fields have values
+      // This handles cases where new fields were added after the config was saved
+      setConfig({ ...DEFAULT_CONFIG, ...savedConfig });
     }
   }, []);
 

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -70,10 +70,17 @@ export default function MainPage() {
     setScanProgress({ message: 'Starting scan...', progress: 0 });
 
     try {
+      // Determine the base URL based on execution environment
+      const baseUrl = config.executionEnvironment === 'local' 
+        ? config.agentServerUrl 
+        : (config.cloudAgentUrl || 'https://app.all-hands.dev');
+      
+      if (!baseUrl) {
+        throw new Error('No agent server URL configured. Please check your configuration.');
+      }
+      
       const scanService = new ScanService({
-        baseUrl: config.executionEnvironment === 'local' 
-          ? config.agentServerUrl! 
-          : config.cloudAgentUrl!,
+        baseUrl,
         apiKey: config.sessionApiKey || undefined,
         llmModel: config.llmModel,
         llmApiKey: config.llmApiKey || undefined,


### PR DESCRIPTION
## Summary
Fixes the "Cannot read properties of undefined (reading 'replace')" error that occurs when scanning a repository.

## Root Cause
When loading saved config from localStorage, if the config was saved before the `cloudAgentUrl` field was added, it would be undefined. The code then tried to call `.replace()` on this undefined value.

## Changes
1. **ConfigContext.tsx**: Merge saved config with `DEFAULT_CONFIG` to ensure all fields have values, even if they weren't present in the saved config
2. **MainPage.tsx**: 
   - Add fallback to `'https://app.all-hands.dev'` if `cloudAgentUrl` is undefined
   - Add explicit error message when no agent server URL is configured

## Testing
- All 23 tests pass
- Build succeeds

## Related Issue
Fixes the scan failure reported by user when entering a repository URL after configuring all API keys.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3d0d1463c99941a1b1d6683aaf9d15b6)