### PR TITLE
Fix scan state persistence when navigating between pages

### DIFF
--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -7,6 +7,17 @@ import { LogEntry } from '@/types/openhands';
 // Re-export LogEntry for convenience
 export type { LogEntry };
 
+export interface ScanProgress {
+  message: string;
+  progress: number;
+}
+
+export interface CurrentAction {
+  eventKind: string;
+  command?: string;
+  observation?: string;
+}
+
 interface AppContextType {
   scanResult: ScanResult | null;
   setScanResult: (result: ScanResult | null) => void;
@@ -21,6 +32,10 @@ interface AppContextType {
   updateVulnerability: (id: string, updates: Partial<Vulnerability>) => void;
   isScanning: boolean;
   setIsScanning: (scanning: boolean) => void;
+  scanProgress: ScanProgress | null;
+  setScanProgress: (progress: ScanProgress | null) => void;
+  currentAction: CurrentAction | null;
+  setCurrentAction: (action: CurrentAction | null) => void;
   logs: LogEntry[];
   addLog: (log: Omit<LogEntry, 'id' | 'timestamp'>) => void;
   clearLogs: () => void;
@@ -33,6 +48,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [selectedVulnerabilities, setSelectedVulnerabilities] = useState<string[]>([]);
   const [agents, setAgents] = useState<Agent[]>([]);
   const [isScanning, setIsScanning] = useState(false);
+  const [scanProgress, setScanProgress] = useState<ScanProgress | null>(null);
+  const [currentAction, setCurrentAction] = useState<CurrentAction | null>(null);
   const [logs, setLogs] = useState<LogEntry[]>([]);
 
   const toggleVulnerability = (id: string) => {
@@ -133,6 +150,10 @@ export function AppProvider({ children }: { children: ReactNode }) {
         updateVulnerability,
         isScanning,
         setIsScanning,
+        scanProgress,
+        setScanProgress,
+        currentAction,
+        setCurrentAction,
         logs,
         addLog,
         clearLogs,

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -20,6 +20,10 @@ export default function MainPage() {
     selectedVulnerabilities,
     isScanning,
     setIsScanning,
+    scanProgress,
+    setScanProgress,
+    currentAction,
+    setCurrentAction,
     agents,
     addAgent,
     updateAgent,
@@ -28,8 +32,6 @@ export default function MainPage() {
   } = useApp();
 
   const [repoUrl, setRepoUrl] = useState('');
-  const [scanProgress, setScanProgress] = useState<{ message: string; progress: number } | null>(null);
-  const [currentAction, setCurrentAction] = useState<{ eventKind: string; command?: string; observation?: string } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [showRawOutput, setShowRawOutput] = useState(false);
 

--- a/src/test/AppContext.test.tsx
+++ b/src/test/AppContext.test.tsx
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { AppProvider, useApp } from '@/contexts/AppContext';
+import { BrowserRouter, Routes, Route, useNavigate } from 'react-router-dom';
+
+// Mock localStorage
+const localStorageMock = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+};
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+// Test component that displays and modifies scan state
+function ScannerPage() {
+  const { 
+    scanProgress, 
+    setScanProgress, 
+    currentAction, 
+    setCurrentAction,
+    isScanning,
+    setIsScanning,
+  } = useApp();
+  const navigate = useNavigate();
+
+  const startScan = () => {
+    setIsScanning(true);
+    setScanProgress({ message: 'Scanning repository...', progress: 50 });
+    setCurrentAction({ eventKind: 'run', command: 'git clone https://github.com/test/repo' });
+  };
+
+  return (
+    <div>
+      <h1>Scanner Page</h1>
+      <button onClick={startScan}>Start Scan</button>
+      <button onClick={() => navigate('/logs')}>Go to Logs</button>
+      {isScanning && <span data-testid="scanning-indicator">Scanning...</span>}
+      {scanProgress && (
+        <div data-testid="scan-progress">
+          <span data-testid="progress-message">{scanProgress.message}</span>
+          <span data-testid="progress-value">{scanProgress.progress}%</span>
+        </div>
+      )}
+      {currentAction && (
+        <div data-testid="current-action">
+          <span data-testid="action-kind">{currentAction.eventKind}</span>
+          <span data-testid="action-command">{currentAction.command}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LogsPage() {
+  const navigate = useNavigate();
+  return (
+    <div>
+      <h1>Logs Page</h1>
+      <button onClick={() => navigate('/')}>Go to Scanner</button>
+    </div>
+  );
+}
+
+const renderWithRouter = () => {
+  return render(
+    <BrowserRouter>
+      <AppProvider>
+        <Routes>
+          <Route path="/" element={<ScannerPage />} />
+          <Route path="/logs" element={<LogsPage />} />
+        </Routes>
+      </AppProvider>
+    </BrowserRouter>
+  );
+};
+
+describe('AppContext - Scan State Persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorageMock.getItem.mockReturnValue(null);
+  });
+
+  it('should persist scanProgress when navigating away and back', async () => {
+    renderWithRouter();
+    
+    // Verify we're on the scanner page
+    expect(screen.getByText('Scanner Page')).toBeInTheDocument();
+    
+    // Start a scan
+    await act(async () => {
+      screen.getByText('Start Scan').click();
+    });
+    
+    // Verify scan state is displayed
+    expect(screen.getByTestId('scanning-indicator')).toBeInTheDocument();
+    expect(screen.getByTestId('progress-message')).toHaveTextContent('Scanning repository...');
+    expect(screen.getByTestId('progress-value')).toHaveTextContent('50%');
+    expect(screen.getByTestId('action-kind')).toHaveTextContent('run');
+    expect(screen.getByTestId('action-command')).toHaveTextContent('git clone https://github.com/test/repo');
+    
+    // Navigate to logs page
+    await act(async () => {
+      screen.getByText('Go to Logs').click();
+    });
+    
+    // Verify we're on the logs page
+    expect(screen.getByText('Logs Page')).toBeInTheDocument();
+    
+    // Navigate back to scanner page
+    await act(async () => {
+      screen.getByText('Go to Scanner').click();
+    });
+    
+    // Verify scan state is still present after navigation
+    expect(screen.getByText('Scanner Page')).toBeInTheDocument();
+    expect(screen.getByTestId('scanning-indicator')).toBeInTheDocument();
+    expect(screen.getByTestId('progress-message')).toHaveTextContent('Scanning repository...');
+    expect(screen.getByTestId('progress-value')).toHaveTextContent('50%');
+    expect(screen.getByTestId('action-kind')).toHaveTextContent('run');
+    expect(screen.getByTestId('action-command')).toHaveTextContent('git clone https://github.com/test/repo');
+  });
+
+  it('should persist isScanning state when navigating', async () => {
+    renderWithRouter();
+    
+    // Start a scan
+    await act(async () => {
+      screen.getByText('Start Scan').click();
+    });
+    
+    expect(screen.getByTestId('scanning-indicator')).toBeInTheDocument();
+    
+    // Navigate away
+    await act(async () => {
+      screen.getByText('Go to Logs').click();
+    });
+    
+    // Navigate back
+    await act(async () => {
+      screen.getByText('Go to Scanner').click();
+    });
+    
+    // isScanning should still be true
+    expect(screen.getByTestId('scanning-indicator')).toBeInTheDocument();
+  });
+
+  it('should persist currentAction state when navigating', async () => {
+    renderWithRouter();
+    
+    // Start a scan (which sets currentAction)
+    await act(async () => {
+      screen.getByText('Start Scan').click();
+    });
+    
+    expect(screen.getByTestId('current-action')).toBeInTheDocument();
+    
+    // Navigate away and back
+    await act(async () => {
+      screen.getByText('Go to Logs').click();
+    });
+    await act(async () => {
+      screen.getByText('Go to Scanner').click();
+    });
+    
+    // currentAction should still be present
+    expect(screen.getByTestId('current-action')).toBeInTheDocument();
+    expect(screen.getByTestId('action-command')).toHaveTextContent('git clone https://github.com/test/repo');
+  });
+
+  it('should not show scan progress before scan starts', () => {
+    renderWithRouter();
+    
+    expect(screen.getByText('Scanner Page')).toBeInTheDocument();
+    expect(screen.queryByTestId('scanning-indicator')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('scan-progress')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('current-action')).not.toBeInTheDocument();
+  });
+});
+
+describe('AppContext - State Updates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorageMock.getItem.mockReturnValue(null);
+  });
+
+  it('should update scanProgress correctly', async () => {
+    renderWithRouter();
+    
+    await act(async () => {
+      screen.getByText('Start Scan').click();
+    });
+    
+    expect(screen.getByTestId('progress-message')).toHaveTextContent('Scanning repository...');
+    expect(screen.getByTestId('progress-value')).toHaveTextContent('50%');
+  });
+
+  it('should update currentAction correctly', async () => {
+    renderWithRouter();
+    
+    await act(async () => {
+      screen.getByText('Start Scan').click();
+    });
+    
+    expect(screen.getByTestId('action-kind')).toHaveTextContent('run');
+    expect(screen.getByTestId('action-command')).toHaveTextContent('git clone https://github.com/test/repo');
+  });
+});


### PR DESCRIPTION
## Problem
When clicking from an active scan to the "Logs" page and back, the scan activity (progress bar, agent activity) would disappear.

## Root Cause
The `scanProgress` and `currentAction` states were local to the `MainPage` component. When the user navigated away, the component unmounted and lost this state.

## Solution
Moved `scanProgress` and `currentAction` from local component state to the `AppContext`, which persists across navigation:

1. **`src/contexts/AppContext.tsx`**: Added `scanProgress`, `setScanProgress`, `currentAction`, and `setCurrentAction` to the context
2. **`src/pages/MainPage.tsx`**: Updated to use context state instead of local state

## Tests Added
Created `src/test/AppContext.test.tsx` with 6 tests covering:
- ✅ `should persist scanProgress when navigating away and back`
- ✅ `should persist isScanning state when navigating`
- ✅ `should persist currentAction state when navigating`
- ✅ `should not show scan progress before scan starts`
- ✅ `should update scanProgress correctly`
- ✅ `should update currentAction correctly`

## Verification
- All 29 tests pass
- Build succeeds

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)