### PR TITLE
Add links to the top left header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,18 +18,29 @@ function Navigation() {
       <div className="container mx-auto px-6 py-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
-            <img 
-              src={openhandsLogo} 
-              alt="OpenHands Logo" 
-              className="w-12 h-12 rounded-lg shadow-lg object-cover"
-            />
+            <Link to="/" aria-label="Go to main page">
+              <img 
+                src={openhandsLogo} 
+                alt="OpenHands Logo" 
+                className="w-12 h-12 rounded-lg shadow-lg object-cover hover:opacity-80 transition-opacity"
+              />
+            </Link>
             <div className="flex flex-col">
-              <h1 className="text-2xl font-bold text-foreground">
-                Vulnerability Fixer
-              </h1>
+              <Link to="/" className="hover:opacity-80 transition-opacity">
+                <h1 className="text-2xl font-bold text-foreground">
+                  Vulnerability Fixer
+                </h1>
+              </Link>
               <div className="flex items-center space-x-2">
                 <span className="text-sm text-muted-foreground">powered by</span>
-                <span className="text-sm font-semibold text-foreground">OpenHands</span>
+                <a 
+                  href="https://openhands.dev" 
+                  target="_blank" 
+                  rel="noopener noreferrer"
+                  className="text-sm font-semibold text-foreground hover:text-primary transition-colors"
+                >
+                  OpenHands
+                </a>
               </div>
             </div>
           </div>

--- a/src/test/Navigation.test.tsx
+++ b/src/test/Navigation.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+describe('Navigation Links in App.tsx', () => {
+  const appTsxPath = path.resolve(__dirname, '../App.tsx');
+  let appContent: string;
+
+  beforeAll(() => {
+    appContent = fs.readFileSync(appTsxPath, 'utf-8');
+  });
+
+  it('should have OpenHands logo wrapped in a Link to main page', () => {
+    // Check for a Link component wrapping the img element with proper navigation
+    expect(appContent).toContain('<Link to="/" aria-label="Go to main page">');
+    expect(appContent).toContain('src={openhandsLogo}');
+  });
+
+  it('should have "Vulnerability Fixer" title wrapped in a Link to main page', () => {
+    // Check for a Link component wrapping the h1 title
+    expect(appContent).toContain('<Link to="/" className="hover:opacity-80 transition-opacity">');
+    expect(appContent).toContain('<h1 className="text-2xl font-bold text-foreground">');
+    expect(appContent).toContain('Vulnerability Fixer');
+  });
+
+  it('should have "powered by OpenHands" as an external link to openhands.dev', () => {
+    // Check for an anchor tag linking to openhands.dev
+    expect(appContent).toContain('href="https://openhands.dev"');
+    expect(appContent).toContain('target="_blank"');
+    expect(appContent).toContain('rel="noopener noreferrer"');
+    // The link text "OpenHands" is inside the anchor tag
+    expect(appContent).toContain('OpenHands');
+    expect(appContent).toContain('</a>');
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds navigation links to the top left header elements as requested in issue #30.

## Changes

- **OpenHands logo**: Now clickable and links to the main page (`/`) with proper hover state and aria-label for accessibility
- **"Vulnerability Fixer" title**: Now clickable and links to the main page (`/`) with proper hover state
- **"powered by OpenHands" text**: Now links to `https://openhands.dev` (opens in new tab with `target="_blank"` and `rel="noopener noreferrer"` for security)

## Testing

Added `Navigation.test.tsx` to verify:
1. OpenHands logo is wrapped in a Link component pointing to `/`
2. "Vulnerability Fixer" title is wrapped in a Link component pointing to `/`
3. "powered by OpenHands" is an external anchor link to `https://openhands.dev`

All tests pass and the build succeeds.

Closes #30

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)