### PR TITLE
Add link for LLM API key when OpenHands provider is selected

### DIFF
--- a/src/pages/ConfigPage.tsx
+++ b/src/pages/ConfigPage.tsx
@@ -440,7 +440,19 @@ export default function ConfigPage() {
             <p className="text-xs text-muted-foreground mt-1">
               {config.llmProvider === 'openai' && 'Please enter OpenAI LLM Key'}
               {config.llmProvider === 'anthropic' && 'Please enter Anthropic LLM Key'}
-              {config.llmProvider === 'openhands' && 'Please enter OpenHands LLM Key'}
+              {config.llmProvider === 'openhands' && (
+                <>
+                  Get your API key from the{' '}
+                  <a
+                    href="https://app.all-hands.dev/settings/api-keys"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-foreground hover:text-muted-foreground underline"
+                  >
+                    OpenHands Cloud settings page
+                  </a>
+                </>
+              )}
             </p>
             <Input
               id="llmApiKey"

--- a/src/test/ConfigPage.test.tsx
+++ b/src/test/ConfigPage.test.tsx
@@ -51,14 +51,19 @@ describe('ConfigPage', () => {
     expect(localRadio).not.toBeChecked();
   });
 
-  it('should display a link to the OpenHands Cloud API keys page', () => {
+  it('should display links to the OpenHands Cloud API keys page', () => {
     renderConfigPage();
     
-    const link = screen.getByRole('link', { name: /openhands cloud settings page/i });
-    expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute('href', 'https://app.all-hands.dev/settings/api-keys');
-    expect(link).toHaveAttribute('target', '_blank');
-    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    // By default, OpenHands is selected as LLM provider, so there should be 2 links:
+    // one in the OpenHands Agent Server section and one in the LLM Provider section
+    const links = screen.getAllByRole('link', { name: /openhands cloud settings page/i });
+    expect(links.length).toBe(2);
+    
+    links.forEach(link => {
+      expect(link).toHaveAttribute('href', 'https://app.all-hands.dev/settings/api-keys');
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
   });
 
   it('should display a note about local storage with updated message', () => {
@@ -105,6 +110,57 @@ describe('ConfigPage', () => {
     expect(link).toHaveAttribute('href', 'https://github.com/settings/tokens/new?scopes=repo&description=CVE%20Remediation%20Tool');
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('should display a link to OpenHands Cloud settings when OpenHands LLM provider is selected', () => {
+    renderConfigPage();
+    
+    // OpenHands is the default LLM provider, so first switch to OpenAI
+    const providerSelect = screen.getByLabelText(/^provider$/i);
+    fireEvent.change(providerSelect, { target: { value: 'openai' } });
+    
+    // Now there should be only one link (from the OpenHands Agent Server section)
+    let links = screen.getAllByRole('link', { name: /openhands cloud settings page/i });
+    expect(links.length).toBe(1);
+    
+    // Now switch back to OpenHands LLM provider
+    fireEvent.change(providerSelect, { target: { value: 'openhands' } });
+    
+    // There should now be two links to OpenHands Cloud settings page
+    // (one for the API key in OpenHands Agent Server section, one in LLM Provider section)
+    links = screen.getAllByRole('link', { name: /openhands cloud settings page/i });
+    expect(links.length).toBe(2);
+    
+    // Both should have the correct attributes
+    links.forEach(link => {
+      expect(link).toHaveAttribute('href', 'https://app.all-hands.dev/settings/api-keys');
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+  });
+
+  it('should not display OpenHands Cloud link in LLM section when other providers are selected', () => {
+    renderConfigPage();
+    
+    // Default is OpenHands, so there should be two links to OpenHands Cloud settings page
+    // (one from the OpenHands Agent Server section, one from the LLM Provider section)
+    let links = screen.getAllByRole('link', { name: /openhands cloud settings page/i });
+    expect(links.length).toBe(2);
+    
+    // Change to OpenAI
+    const providerSelect = screen.getByLabelText(/^provider$/i);
+    fireEvent.change(providerSelect, { target: { value: 'openai' } });
+    
+    // Now only one link (from the OpenHands Agent Server section)
+    links = screen.getAllByRole('link', { name: /openhands cloud settings page/i });
+    expect(links.length).toBe(1);
+    
+    // Change to Anthropic
+    fireEvent.change(providerSelect, { target: { value: 'anthropic' } });
+    
+    // Still only one link
+    links = screen.getAllByRole('link', { name: /openhands cloud settings page/i });
+    expect(links.length).toBe(1);
   });
 
   it('should show error message when testing OpenHands connection without API key', async () => {


### PR DESCRIPTION
## Summary

This PR adds a link to the OpenHands Cloud settings page when the OpenHands LLM provider is selected in the LLM Provider configuration section.

## Changes

- **ConfigPage.tsx**: Modified the LLM API Key section to display a link to "OpenHands Cloud settings page" when the OpenHands provider is selected. This link follows the same pattern as the existing link in the OpenHands Agent Server section.

- **ConfigPage.test.tsx**: Added and updated tests to verify:
  - The link appears when the OpenHands LLM provider is selected
  - The link does not appear when other providers (OpenAI, Anthropic) are selected
  - Both links (Agent Server section and LLM Provider section) have correct attributes

## Testing

All existing and new tests pass:
- `should display links to the OpenHands Cloud API keys page` - verifies both links appear by default (since OpenHands is the default LLM provider)
- `should display a link to OpenHands Cloud settings when OpenHands LLM provider is selected` - verifies the link appears when switching to OpenHands
- `should not display OpenHands Cloud link in LLM section when other providers are selected` - verifies the link doesn't appear for OpenAI/Anthropic

## Fixes

Fixes #33

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)