### PR TITLE
Simplify README, add GitHub link in header, and add MIT license

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -1,0 +1,159 @@
+# Implementation Details
+
+This document provides detailed technical information about the Vulnerability Fixer application.
+
+## Features
+
+- **Automated Scanning** - Run Trivy security scans on GitHub repositories via OpenHands agents
+- **Report Upload** - Upload vulnerability reports from any scanner (Snyk, Veracode, Checkmarx, etc.)
+- **AI Format Conversion** - Automatically detect and convert report formats to a common schema
+- **Automated Remediation** - AI agents generate and test fixes for selected vulnerabilities
+- **GitHub Integration** - Automatically create pull requests with fix implementations
+- **Real-time Monitoring** - Track agent progress with live status updates and logs
+- **Parallel Processing** - Fix multiple vulnerabilities simultaneously
+
+## Local Agent Setup
+
+To run with a local OpenHands agent server instead of OpenHands Cloud:
+
+### 1. Start the Agent Server
+
+```bash
+docker run -p 8000:8000 -p 8001:8001 \
+  -e OH_ENABLE_VNC=false \
+  -e OH_ALLOW_CORS_ORIGINS='["*"]' \
+  ghcr.io/openhands/agent-server:65d556e-python
+```
+
+Find the latest Docker image at: https://github.com/openhands/software-agent-sdk/pkgs/container/agent-server
+
+### 2. Configure the Application
+
+1. Navigate to the Configuration page
+2. Select **Local Agent** as the execution environment
+3. Set **Agent Server URL** to `http://localhost:8000`
+4. Optionally set **Session API Key** if configured on the server
+
+## Usage Flows
+
+### Flow 1: Trivy Automated Repository Scan
+
+1. **Scan**
+   - Enter the GitHub repository URL in the scan box
+   - Click **Scan Repository**
+   - The agent will clone the repository and run a Trivy scan
+   - Wait for the scan to complete
+   - Vulnerabilities will be displayed in the table
+
+2. **Remediate**
+   - Select vulnerabilities to fix using the checkboxes
+   - Click **Remediate Selected**
+   - The agent will analyze, generate fixes, create a branch, and open a pull request
+   - Monitor real-time progress and agent logs in the UI
+   - Access pull request links directly from the table
+
+### Flow 2: Upload Report Scan (Manual)
+
+1. **Upload & Convert**
+   - Click the **Upload Report** tab
+   - Enable **AI-based Format Converter** (recommended for all formats)
+   - Upload your vulnerability report file (JSON, XML, SARIF, etc.)
+   - The agent will detect the format and convert it to the common schema
+   - Wait for conversion to complete
+   - Parsed vulnerabilities will be shown in the table
+
+2. **Remediate**
+   - Select vulnerabilities to fix using the checkboxes
+   - Click **Remediate Selected**
+   - The agent will analyze, generate fixes, create a branch, and open a pull request
+   - Monitor real-time progress and agent logs in the UI
+   - Access pull request links directly from the table
+
+## Technology Stack
+
+### Frontend
+
+| Technology      | Version  | Purpose                             |
+|-----------------|----------|-------------------------------------|
+| React           | 18       | UI framework                        |
+| TypeScript      | 5.0      | Type-safe development               |
+| Vite            | 5.4      | Build tool and dev server           |
+| Tailwind CSS    | 3.4      | Styling and UI components           |
+| React Router    | Latest   | Client-side routing                 |
+| Lucide React    | Latest   | Icon library                        |
+
+### Backend/Services
+
+| Service                   | Purpose                                      |
+|---------------------------|----------------------------------------------|
+| OpenHands TypeScript SDK  | Agent communication                          |
+| OpenHands Agent Server    | AI agent execution environment               |
+| Trivy                     | Vulnerability scanner (via OpenHands agents) |
+| GitHub API                | Repository and PR management                 |
+
+## Project Structure
+
+```
+src/
+├── pages/              # Main application pages
+│   ├── MainPage.tsx    # Scanner and vulnerability table
+│   ├── LogsPage.tsx    # Agent logs viewer
+│   └── ConfigPage.tsx  # Configuration management
+├── services/           # Core business logic
+│   ├── openHandsLocalClient.ts    # Local agent SDK client
+│   ├── openhandsCloudClient.ts    # Cloud agent REST client
+│   ├── scanService.ts             # Repository scanning
+│   ├── remediationService.ts      # Vulnerability fixing
+│   └── formatConverterService.ts  # Report format conversion
+├── components/         # Reusable UI components
+│   ├── VulnerabilityTable.tsx  # Main vulnerability display
+│   ├── AgentMonitor.tsx        # Real-time agent status
+│   └── LogViewer.tsx           # Terminal-style log viewer
+├── contexts/          # React contexts
+│   ├── ConfigContext.tsx   # Configuration state
+│   └── AppContext.tsx      # Application state
+└── types/             # TypeScript definitions
+    ├── vulnerability.ts  # Vulnerability data types
+    ├── config.ts        # Configuration types
+    └── openhands.ts     # OpenHands API types
+```
+
+## Configuration
+
+### Agent Configuration
+
+The application supports both local and cloud OpenHands deployments:
+
+| Deployment Type  | Description                                 | Configuration                            |
+|------------------|---------------------------------------------|------------------------------------------|
+| **Local Agent**  | Run OpenHands server locally via Docker     | Agent Server URL + Session Key           |
+| **Cloud Agent**  | Use OpenHands Cloud service                 | OpenHands API Key                        |
+
+### LLM Configuration
+
+| Provider        | Requirements         | Models Supported                |
+|-----------------|----------------------|---------------------------------|
+| **OpenAI**      | OpenAI API key       | GPT-4, GPT-4o, GPT-3.5-turbo    |
+| **Anthropic**   | Anthropic API key    | Claude 3.5 Sonnet, Claude 3 Opus|
+| **OpenHands**   | OpenHands API key    | Various models via OpenHands    |
+
+### GitHub Configuration
+
+| Requirement      | Description                                         |
+|------------------|-----------------------------------------------------|
+| **GitHub Token** | Personal Access Token with `repo` scope             |
+| **Get Token**    | https://github.com/settings/tokens                  |
+| **Permissions**  | `repo` - Full repository access                     |
+
+### Storage
+
+All configuration is stored in **browser localStorage**:
+
+| Data Type            | Storage Location     |
+|----------------------|----------------------|
+| Agent settings       | Browser localStorage |
+| LLM configuration    | Browser localStorage |
+| GitHub token         | Browser localStorage |
+| Recent scan results  | Browser localStorage (limited) |
+
+**🔒 Security Note**: All credentials are stored locally in your browser only and never sent to external servers (except for the services they authenticate with).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 OpenHands
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,268 +1,72 @@
 # Vulnerability Fixer
 
-An AI-powered web application that automatically scans repositories for security vulnerabilities and creates pull requests with fixes using OpenHands agents.
+An AI-powered web application that automatically scans repositories for security vulnerabilities and creates pull requests with fixes. Built with [OpenHands](https://openhands.dev) to demonstrate how to build AI-powered applications using the [OpenHands Cloud API](https://app.all-hands.dev).
 
-## Overview
+## What It Does
 
-Vulnerability Fixer is a React application that uses OpenHands AI agents to scan code for security vulnerabilities and automatically generate fixes. It supports both automated Trivy scanning and manual report uploads from various security scanners.
+**Vulnerability Fixer** uses AI agents to:
 
-## Features
+1. **Scan** - Run Trivy security scans on GitHub repositories or upload reports from other scanners
+2. **Analyze** - Identify and prioritize security vulnerabilities  
+3. **Fix** - Automatically generate code fixes using AI
+4. **Ship** - Create pull requests with the fixes
 
-- **Automated Scanning** - Run Trivy security scans on GitHub repositories via OpenHands agents
-- **Report Upload** - Upload vulnerability reports from any scanner (Snyk, Veracode, Checkmarx, etc.)
-- **AI Format Conversion** - Automatically detect and convert report formats to a common schema
-- **Automated Remediation** - AI agents generate and test fixes for selected vulnerabilities
-- **GitHub Integration** - Automatically create pull requests with fix implementations
-- **Real-time Monitoring** - Track agent progress with live status updates and logs
-- **Parallel Processing** - Fix multiple vulnerabilities simultaneously in the Vulnerability Fixer application
+## Quick Start
 
-### System Flow
+### Using OpenHands Cloud (Recommended)
 
-```
-┌─────────────┐       ┌─────────────────┐
-│   Browser   │  ───▶ │  Local / Cloud  │
-│  (React UI) │       │    OpenHands    │
-└─────────────┘       │  Agent Server   │
-                      └──────┬──────────┘
-                             │
-          ┌──────────────────┼─────────────┐
-          ▼                  ▼             ▼
-     ┌────────┐        ┌─────────┐   ┌────────┐
-     │ Trivy  │        │   LLM   │   │ GitHub │
-     │Scanner │        │  APIs   │   │  API   │
-     └────────┘        └─────────┘   └────────┘
-```
+1. Clone and install:
+   ```bash
+   git clone https://github.com/OpenHands/vulnerability-fixer.git
+   cd vulnerability-fixer
+   npm install
+   npm run dev
+   ```
+
+2. Open `http://localhost:3001` and configure:
+   - **OpenHands Cloud API Key** - Get one from [OpenHands Cloud](https://app.all-hands.dev/settings/api-keys)
+   - **LLM API Key** - Your OpenAI, Anthropic, or OpenHands LLM key
+   - **GitHub Token** - [Create a token](https://github.com/settings/tokens/new?scopes=repo) with `repo` scope
+
+3. Enter a GitHub repository URL and click **Scan Repository**
+
+### Using Local OpenHands Agent
+
+See [IMPLEMENTATION.md](IMPLEMENTATION.md) for instructions on running with a local OpenHands agent server.
 
 ## How It Works
 
-### 1. Scan Phase
-- **Auto Trivy Scan**: Enter a GitHub URL → Agent clones repo → Runs Trivy → Displays vulnerabilities
-- **Upload Report**: Upload report → AI detects format → Converts to common schema → Displays vulnerabilities
-
-### 2. Fix Phase
-- Select vulnerabilities → Start agent:
-  - Analyzes vulnerability
-  - Generates fix using LLM
-  - Creates branch and commits changes
-  - Opens pull request on GitHub
-
-### 3. Monitor Phase
-- Real-time status dashboard
-- View agent logs
-- Access pull request links
-
-
-## Getting Started
-
-### Prerequisites
-
-- Node.js 18+ and npm
-- Docker (for running OpenHands agent server)
-- GitHub Personal Access Token (with `repo` scope)
-- LLM API key (OpenAI, Anthropic, or other supported provider)
-
-## Installation
-
-### 1. Clone and Install
-
-```bash
-git clone https://github.com/OpenHands/vulnerability-fixer.git
-cd vulnerability-fixer
+```
+┌─────────────┐       ┌─────────────────┐       ┌────────┐
+│   Browser   │  ───▶ │    OpenHands    │  ───▶ │ GitHub │
+│  (React UI) │       │   Cloud / Local │       │  API   │
+└─────────────┘       └─────────────────┘       └────────┘
+                             │
+                      ┌──────┴──────┐
+                      ▼             ▼
+                 ┌────────┐   ┌─────────┐
+                 │ Trivy  │   │   LLM   │
+                 │Scanner │   │  APIs   │
+                 └────────┘   └─────────┘
 ```
 
-#### 2. Configure GitHub Packages Authentication
+1. Enter a GitHub URL or upload a vulnerability report
+2. The OpenHands agent scans the repository using Trivy
+3. Select vulnerabilities to fix from the results table
+4. The agent analyzes each vulnerability and generates fixes
+5. Pull requests are automatically created on GitHub
 
-This project uses `@openhands/typescript-client` from GitHub Packages, which requires authentication.
+## Building on OpenHands
 
-**Create a GitHub Personal Access Token:**
-1. Go to [GitHub Settings > Developer settings > Personal access tokens](https://github.com/settings/tokens)
-2. Click "Generate new token (classic)"
-3. Select the `repo` scope
-4. Copy the generated token
+This project demonstrates key patterns for building apps with [OpenHands Cloud](https://app.all-hands.dev):
 
-### 3. Start OpenHands Agent Server (Local Only)
+- **Conversation Management** - Creating and managing agent conversations
+- **Task Execution** - Sending prompts and receiving results
+- **Real-time Updates** - Streaming agent progress and logs
+- **Error Handling** - Managing agent states and failures
 
-If using local agents:
+See [IMPLEMENTATION.md](IMPLEMENTATION.md) for technical details and the [OpenHands SDK documentation](https://docs.openhands.dev/sdk/getting-started).
 
-```bash
-docker run -p 8000:8000 -p 8001:8001 \
-  -e OH_ENABLE_VNC=false \
-  -e OH_ALLOW_CORS_ORIGINS='["*"]' \
-  ghcr.io/openhands/agent-server:65d556e-python
-```
+## License
 
-You can always find the latest OpenHands Agent Server Docker image here:
-https://github.com/openhands/software-agent-sdk/pkgs/container/agent-server
-
-The project includes a `.npmrc` file that uses this token for authentication with GitHub Packages.
-
-#### 4. Install Application Dependencies
-
-```bash
-npm install
-```
-
-
-### 5. Start the Application
-
-```bash
-npm run dev
-```
-
-Access at `http://localhost:3001`
-
-## Configuration
-
-Navigate to **Configuration** page and set:
-
-#### 6. Configure the Application
-
-1. Open `http://localhost:3001` in your browser
-2. Navigate to the Configuration page (Settings icon)
-3. Configure the following:
-   - **OpenHands Agent**: Local or Cloud
-      - If **Local**
-         - **Agent Server URL**: `http://localhost:8000` (for local Docker setup)
-         - **Agent Session**: `SESSION_API_KEY` env variable that agent server runs.
-      - If **Cloud**
-         - **OpenHands API Key**: Key from OpenHands Cloud.
-   - **LLM Provider**: Select your provider
-   - **LLM Model**: Choose the model
-   - **LLM API Key**: Enter your API key
-   - **GitHub Token**: Enter your GitHub Personal Access Token
-   
-4. Click "Save Configuration"
-5. Click "Test Connection" to verify setup
-
-
-## Usage
-
-### Flow 1: Trivy Automated Repository Scan
-
-1. **Scan**
-   - Enter the GitHub repository URL in the scan box
-   - Click **Scan Repository**
-   - The agent will clone the repository and run a Trivy scan
-   - Wait for the scan to complete
-   - Vulnerabilities will be displayed in the table
-
-2. **Remediate**
-   - Select vulnerabilities to fix using the checkboxes
-   - Click **Remediate Selected**
-   - The agent will analyze, generate fixes, create a branch, and open a pull request
-   - Monitor real-time progress and agent logs in the UI
-   - Access pull request links directly from the table
-
----
-
-### Flow 2: Upload Report Scan (Manual)
-
-1. **Upload & Convert**
-   - Click the **Upload Report** tab
-   - Enable **AI-based Format Converter** (recommended for all formats)
-   - Upload your vulnerability report file (JSON, XML, SARIF, etc.)
-   - The agent will detect the format and convert it to the common schema
-   - Wait for conversion to complete
-   - Parsed vulnerabilities will be shown in the table
-
-2. **Remediate**
-   - Select vulnerabilities to fix using the checkboxes
-   - Click **Remediate Selected**
-   - The agent will analyze, generate fixes, create a branch, and open a pull request
-   - Monitor real-time progress and agent logs in the UI
-   - Access pull request links directly from the table
-
-## 💻 Technology Stack
-
-### Frontend
-
-| Technology      | Version  | Purpose                             |
-|-----------------|----------|-------------------------------------|
-| React           | 18       | UI framework                        |
-| TypeScript      | 5.0      | Type-safe development               |
-| Vite            | 5.4      | Build tool and dev server           |
-| Tailwind CSS    | 3.4      | Styling and UI components           |
-| React Router    | Latest   | Client-side routing                 |
-| Lucide React    | Latest   | Icon library                        |
-
-### Backend/Services
-
-| Service                   | Purpose                                      |
-|---------------------------|----------------------------------------------|
-| OpenHands TypeScript SDK  | Agent communication                          |
-| OpenHands Agent Server    | AI agent execution environment               |
-| Trivy                     | Vulnerability scanner (via OpenHands agents) |
-| GitHub API                | Repository and PR management                 |
-
-## Project Structure
-
-```
-src/
-├── pages/              # Main application pages
-│   ├── MainPage.tsx    # Scanner and vulnerability table
-│   ├── LogsPage.tsx    # Agent logs viewer
-│   └── ConfigPage.tsx  # Configuration management
-├── services/           # Core business logic
-│   ├── openHandsLocalClient.ts    # Local agent SDK client
-│   ├── openhandsCloudClient.ts    # Cloud agent REST client
-│   ├── scanService.ts             # Repository scanning
-│   ├── remediationService.ts      # Vulnerability fixing
-│   └── formatConverterService.ts  # Report format conversion
-├── components/         # Reusable UI components
-│   ├── VulnerabilityTable.tsx  # Main vulnerability display
-│   ├── AgentMonitor.tsx        # Real-time agent status
-│   └── LogViewer.tsx           # Terminal-style log viewer
-├── contexts/          # React contexts
-│   ├── ConfigContext.tsx   # Configuration state
-│   └── AppContext.tsx      # Application state
-└── types/             # TypeScript definitions
-    ├── vulnerability.ts  # Vulnerability data types
-    ├── config.ts        # Configuration types
-    └── openhands.ts     # OpenHands API types
-```
-
-
-## ⚙️ Configuration
-
-### Agent Configuration
-
-The application supports both local and cloud OpenHands deployments:
-
-| Deployment Type  | Description                                 | Configuration                            |
-|------------------|---------------------------------------------|------------------------------------------|
-| **Local Agent**  | Run OpenHands server locally via Docker     | Agent Server URL + Session Key           |
-| **Cloud Agent**  | Use OpenHands Cloud service                 | OpenHands API Key                        |
-
-**Configuration Steps:**
-1. Select execution environment (Local/Cloud)
-2. Enter agent server URL
-3. Provide session/API key
-
-### LLM Configuration
-
-| Provider        | Requirements         | Models Supported                |
-|-----------------|----------------------|---------------------------------|
-| **OpenAI**      | OpenAI API key       | GPT-4, GPT-4o, GPT-3.5-turbo    |
-| **Anthropic**   | Anthropic API key    | Claude 3.5 Sonnet, Claude 3 Opus|
-| **Others**      | Provider-specific    | Configure via OpenHands server  |
-
-### GitHub Configuration
-
-| Requirement      | Description                                         |
-|------------------|-----------------------------------------------------|
-| **GitHub Token** | Personal Access Token with `repo` scope             |
-| **Get Token**    | https://github.com/settings/tokens                  |
-| **Permissions**  | `repo` - Full repository access                     |
-
-### Storage
-
-All configuration is stored in **browser localStorage**:
-
-| Data Type            | Storage Location     |
-|----------------------|----------------------|
-| Agent settings       | Browser localStorage |
-| LLM configuration    | Browser localStorage |
-| GitHub token         | Browser localStorage |
-| Recent scan results  | Browser localStorage (limited) |
-
-**🔒 Security Note**: All credentials are stored locally in your browser only and never sent to external servers (except for the services they authenticate with).
+MIT License - see [LICENSE](LICENSE) for details.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { Routes, Route, Link, useLocation } from 'react-router-dom';
-import { Settings, FileText } from 'lucide-react';
+import { Settings, FileText, Github } from 'lucide-react';
 import { ConfigProvider } from './contexts/ConfigContext';
 import { AppProvider } from './contexts/AppContext';
 import { ErrorBoundary } from './components/ErrorBoundary';
@@ -8,6 +8,7 @@ import MainPage from './pages/MainPage';
 import ConfigPage from './pages/ConfigPage';
 import LogsPage from './pages/LogsPage';
 import openhandsLogo from './assets/openhandslogo.jpeg';
+import { REPO_URL } from './utils/environment';
 
 function Navigation() {
   const location = useLocation();
@@ -83,6 +84,15 @@ function Navigation() {
               <Settings className="w-4 h-4" />
               <span>Configuration</span>
             </Link>
+            <a
+              href={REPO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="px-3 py-2 rounded-lg transition-all text-muted-foreground hover:bg-secondary hover:text-foreground"
+              aria-label="View source on GitHub"
+            >
+              <Github className="w-5 h-5" />
+            </a>
           </div>
         </div>
       </div>

--- a/src/test/ConfigPage.test.tsx
+++ b/src/test/ConfigPage.test.tsx
@@ -21,7 +21,7 @@ global.fetch = mockFetch;
 // Mock the environment module
 vi.mock('@/utils/environment', () => ({
   isVercelDeployment: vi.fn(() => false),
-  REPO_URL: 'https://github.com/OpenHands/cve-remediation',
+  REPO_URL: 'https://github.com/OpenHands/vulnerability-fixer',
 }));
 
 const renderConfigPage = () => {
@@ -260,7 +260,7 @@ describe('ConfigPage on Vercel', () => {
       expect(screen.getByText(/local agent is not available on the hosted version/i)).toBeInTheDocument();
       expect(screen.getByRole('link', { name: /download the code/i })).toHaveAttribute(
         'href',
-        'https://github.com/OpenHands/cve-remediation'
+        'https://github.com/OpenHands/vulnerability-fixer'
       );
     });
   });

--- a/src/test/environment.test.ts
+++ b/src/test/environment.test.ts
@@ -44,7 +44,7 @@ describe('environment utilities', () => {
 
   describe('REPO_URL', () => {
     it('should be the correct GitHub repository URL', () => {
-      expect(REPO_URL).toBe('https://github.com/OpenHands/cve-remediation');
+      expect(REPO_URL).toBe('https://github.com/OpenHands/vulnerability-fixer');
     });
   });
 });

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -13,4 +13,4 @@ export function isVercelDeployment(): boolean {
 /**
  * The GitHub repository URL for this project
  */
-export const REPO_URL = 'https://github.com/OpenHands/cve-remediation';
+export const REPO_URL = 'https://github.com/OpenHands/vulnerability-fixer';


### PR DESCRIPTION
## Summary

This PR makes several improvements to documentation and UI:

### README Simplification
- Simplified README to focus on the core functionality (vulnerability scanning) and demonstrating how to build apps on OpenHands Cloud
- Moved detailed implementation documentation to a new IMPLEMENTATION.md file

### UI Changes
- Added GitHub icon link in the top-right of the navigation header that links to the repository

### License
- Added MIT LICENSE file

### Bug Fix
- Updated REPO_URL from `cve-remediation` to `vulnerability-fixer` to match the actual repository name

## Testing

All existing tests pass.