### PR TITLE
fix: handle Vercel ESM imports and OpenHands Trivy result retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Vulnerability Fixer 
+# Vulnerability Fixer
 
 An AI-powered web application that automatically scans repositories for security vulnerabilities and creates pull requests with fixes. Built with [OpenHands](https://openhands.dev) to demonstrate how to build AI-powered applications using the [OpenHands Cloud API](https://app.all-hands.dev).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Vulnerability Fixer
+# Vulnerability Fixer 
 
 An AI-powered web application that automatically scans repositories for security vulnerabilities and creates pull requests with fixes. Built with [OpenHands](https://openhands.dev) to demonstrate how to build AI-powered applications using the [OpenHands Cloud API](https://app.all-hands.dev).
 

--- a/api/test-connection.ts
+++ b/api/test-connection.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { getOpenHandsCloudAuthCheckUrl } from '../src/lib/openhandsCloudApi';
+import { getOpenHandsCloudAuthCheckUrl } from '../src/lib/openhandsCloudApi.js';
 
 async function testOpenHands(apiKey: string): Promise<{ success: boolean; error?: string }> {
   const response = await fetch(getOpenHandsCloudAuthCheckUrl(), {

--- a/src/services/openhandsCloudClient.ts
+++ b/src/services/openhandsCloudClient.ts
@@ -482,6 +482,85 @@ export class OpenHandsClient {
     }
   }
 
+  private async resumeSandbox(sandboxId: string): Promise<void> {
+    console.log('[OpenHands V1 API] Resuming sandbox:', sandboxId);
+    await this.apiRequest<{ success: boolean }>(
+      'POST',
+      `/api/v1/sandboxes/${sandboxId}/resume`
+    );
+  }
+
+  private async ensureSandboxRunning(conversationId: string): Promise<AppConversation> {
+    let conversation = await this.getConversation(conversationId);
+
+    if (conversation.sandbox_status !== 'PAUSED' || !conversation.sandbox_id) {
+      return conversation;
+    }
+
+    await this.resumeSandbox(conversation.sandbox_id);
+
+    const deadline = Date.now() + 30000;
+
+    conversation = await this.getConversation(conversationId);
+    while (conversation.sandbox_status !== 'RUNNING' && Date.now() < deadline) {
+      if (conversation.sandbox_status === 'ERROR' || conversation.sandbox_status === 'MISSING') {
+        break;
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      conversation = await this.getConversation(conversationId);
+    }
+
+    return conversation;
+  }
+
+  private async getTrivyScanResults(conversationId: string): Promise<string | null> {
+    const possiblePaths = [
+      '/workspace/project/trivy-results.json',
+      '/workspace/trivy-results.json',
+      'trivy-results.json',
+    ];
+
+    let conversation = await this.ensureSandboxRunning(conversationId);
+
+    const tryPaths = async (): Promise<string | null> => {
+      for (const path of possiblePaths) {
+        try {
+          const fileContent = await this.downloadFile(conversationId, path);
+
+          if (fileContent.trim().length > 0) {
+            console.log('[OpenHands CLOUD] Retrieved Trivy results from:', path);
+            return fileContent;
+          }
+
+          console.warn('[OpenHands CLOUD] Trivy results file was empty at:', path);
+        } catch (error) {
+          console.warn(
+            '[OpenHands CLOUD] Failed to download Trivy results from:',
+            path,
+            error instanceof Error ? error.message : String(error)
+          );
+        }
+      }
+
+      return null;
+    };
+
+    let trivyResultContent = await tryPaths();
+    if (trivyResultContent) {
+      return trivyResultContent;
+    }
+
+    if (conversation.sandbox_status === 'PAUSED' && conversation.sandbox_id) {
+      conversation = await this.ensureSandboxRunning(conversationId);
+      if (conversation.sandbox_status === 'RUNNING') {
+        trivyResultContent = await tryPaths();
+      }
+    }
+
+    return trivyResultContent;
+  }
+
   /**
    * V1 API: Get the completion result from the agent
    * Tries multiple methods to retrieve the result
@@ -974,8 +1053,8 @@ export class OpenHandsClient {
       // Download the trivy results file directly using the OpenHands Cloud API
       // This avoids output truncation issues when reading large files via cat
       options.onEvent?.({ stage: 'parsing', message: 'Downloading scan results...' });
-      
-      const trivyResultContent = await this.downloadFile(conversationId, '/workspace/project/trivy-results.json');
+
+      const trivyResultContent = await this.getTrivyScanResults(conversationId);
 
       if (!trivyResultContent) {
         throw new Error('Failed to get Trivy scan results from agent');

--- a/src/services/openhandsCloudClient.ts
+++ b/src/services/openhandsCloudClient.ts
@@ -214,6 +214,37 @@ export class OpenHandsClient {
     return response.json();
   }
 
+  private async apiRequestText(
+    method: string,
+    endpoint: string,
+    body?: object
+  ): Promise<string> {
+    const url = `${this.proxiedBaseUrl}${this.getEndpoint(endpoint)}`;
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${this.getApiKey()}`,
+    };
+
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`API request failed (${response.status}): ${error}`);
+    }
+
+    const contentType = response.headers.get('content-type') || '';
+    if (contentType.includes('application/json')) {
+      const parsed = await response.json();
+      return typeof parsed === 'string' ? parsed : JSON.stringify(parsed);
+    }
+
+    return response.text();
+  }
+
   /**
    * V1 API: Create a new conversation with an initial message (streaming)
    * Uses /api/v1/app-conversations/stream-start endpoint
@@ -668,7 +699,7 @@ export class OpenHandsClient {
     const endpoint = `/api/v1/app-conversations/${conversationId}/file?file_path=${encodeURIComponent(filePath)}`;
     
     try {
-      const fileContent = await this.apiRequest<string>('GET', endpoint);
+      const fileContent = await this.apiRequestText('GET', endpoint);
       console.log('[OpenHands V1 API] Downloaded file, size:', fileContent.length);
       return fileContent;
     } catch (error) {

--- a/src/services/openhandsCloudClient.ts
+++ b/src/services/openhandsCloudClient.ts
@@ -482,38 +482,6 @@ export class OpenHandsClient {
     }
   }
 
-  private async resumeSandbox(sandboxId: string): Promise<void> {
-    console.log('[OpenHands V1 API] Resuming sandbox:', sandboxId);
-    await this.apiRequest<{ success: boolean }>(
-      'POST',
-      `/api/v1/sandboxes/${sandboxId}/resume`
-    );
-  }
-
-  private async ensureSandboxRunning(conversationId: string): Promise<AppConversation> {
-    let conversation = await this.getConversation(conversationId);
-
-    if (conversation.sandbox_status !== 'PAUSED' || !conversation.sandbox_id) {
-      return conversation;
-    }
-
-    await this.resumeSandbox(conversation.sandbox_id);
-
-    const deadline = Date.now() + 30000;
-
-    conversation = await this.getConversation(conversationId);
-    while (conversation.sandbox_status !== 'RUNNING' && Date.now() < deadline) {
-      if (conversation.sandbox_status === 'ERROR' || conversation.sandbox_status === 'MISSING') {
-        break;
-      }
-
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      conversation = await this.getConversation(conversationId);
-    }
-
-    return conversation;
-  }
-
   private async getTrivyScanResults(conversationId: string): Promise<string | null> {
     const possiblePaths = [
       '/workspace/project/trivy-results.json',
@@ -521,44 +489,26 @@ export class OpenHandsClient {
       'trivy-results.json',
     ];
 
-    let conversation = await this.ensureSandboxRunning(conversationId);
+    for (const path of possiblePaths) {
+      try {
+        const fileContent = await this.downloadFile(conversationId, path);
 
-    const tryPaths = async (): Promise<string | null> => {
-      for (const path of possiblePaths) {
-        try {
-          const fileContent = await this.downloadFile(conversationId, path);
-
-          if (fileContent.trim().length > 0) {
-            console.log('[OpenHands CLOUD] Retrieved Trivy results from:', path);
-            return fileContent;
-          }
-
-          console.warn('[OpenHands CLOUD] Trivy results file was empty at:', path);
-        } catch (error) {
-          console.warn(
-            '[OpenHands CLOUD] Failed to download Trivy results from:',
-            path,
-            error instanceof Error ? error.message : String(error)
-          );
+        if (fileContent.trim().length > 0) {
+          console.log('[OpenHands CLOUD] Retrieved Trivy results from:', path);
+          return fileContent;
         }
-      }
 
-      return null;
-    };
-
-    let trivyResultContent = await tryPaths();
-    if (trivyResultContent) {
-      return trivyResultContent;
-    }
-
-    if (conversation.sandbox_status === 'PAUSED' && conversation.sandbox_id) {
-      conversation = await this.ensureSandboxRunning(conversationId);
-      if (conversation.sandbox_status === 'RUNNING') {
-        trivyResultContent = await tryPaths();
+        console.warn('[OpenHands CLOUD] Trivy results file was empty at:', path);
+      } catch (error) {
+        console.warn(
+          '[OpenHands CLOUD] Failed to download Trivy results from:',
+          path,
+          error instanceof Error ? error.message : String(error)
+        );
       }
     }
 
-    return trivyResultContent;
+    return null;
   }
 
   /**

--- a/src/test/openhandsCloudClient.test.ts
+++ b/src/test/openhandsCloudClient.test.ts
@@ -46,8 +46,22 @@ function createStreamingResponse(conversationId: string, tasks: object[] = []) {
 function createJsonResponse<T>(data: T) {
   return {
     ok: true,
+    headers: {
+      get: (name: string) => name === 'content-type' ? 'application/json' : null,
+    },
     text: () => Promise.resolve(JSON.stringify(data)),
     json: () => Promise.resolve(data),
+  };
+}
+
+function createTextResponse(text: string, contentType: string = 'text/plain') {
+  return {
+    ok: true,
+    headers: {
+      get: (name: string) => name === 'content-type' ? contentType : null,
+    },
+    text: () => Promise.resolve(text),
+    json: () => Promise.resolve(JSON.parse(text)),
   };
 }
 
@@ -412,6 +426,35 @@ describe('OpenHandsClient', () => {
   });
 
   describe('scanRepository result retrieval', () => {
+    it('parses Trivy results when the file endpoint returns raw text content', async () => {
+      const trivyOutput = {
+        SchemaVersion: 2,
+        Results: [
+          {
+            Target: 'package-lock.json',
+            Vulnerabilities: [],
+          },
+        ],
+      };
+
+      mockFetch
+        .mockResolvedValueOnce(createStreamingResponse('scan-conv-text'))
+        .mockResolvedValueOnce(createJsonResponse([{
+          id: 'scan-conv-text',
+          execution_status: 'finished',
+          sandbox_status: 'RUNNING',
+        }]))
+        .mockResolvedValueOnce(createJsonResponse({
+          items: [],
+          next_page_id: null,
+        }))
+        .mockResolvedValueOnce(createTextResponse(JSON.stringify(trivyOutput)));
+
+      const result = await client.scanRepository('https://github.com/test/repo');
+
+      expect(result).toEqual(trivyOutput);
+    });
+
     it('falls back to the workspace root Trivy results file when the project path is empty', async () => {
       const trivyOutput = {
         SchemaVersion: 2,

--- a/src/test/openhandsCloudClient.test.ts
+++ b/src/test/openhandsCloudClient.test.ts
@@ -443,12 +443,6 @@ describe('OpenHandsClient', () => {
           items: [],
           next_page_id: null,
         }))
-        .mockResolvedValueOnce(createJsonResponse([{
-          id: 'scan-conv-123',
-          execution_status: 'finished',
-          sandbox_status: 'RUNNING',
-          sandbox_id: 'sandbox-123',
-        }]))
         .mockResolvedValueOnce(createJsonResponse(''))
         .mockResolvedValueOnce(createJsonResponse(JSON.stringify(trivyOutput)));
 
@@ -456,67 +450,17 @@ describe('OpenHandsClient', () => {
 
       expect(result).toEqual(trivyOutput);
       expect(mockFetch).toHaveBeenNthCalledWith(
-        5,
+        4,
         'http://localhost:3000/api/cloud/v1/app-conversations/scan-conv-123/file?file_path=%2Fworkspace%2Fproject%2Ftrivy-results.json',
         expect.objectContaining({
           method: 'GET',
         })
       );
       expect(mockFetch).toHaveBeenNthCalledWith(
-        6,
+        5,
         'http://localhost:3000/api/cloud/v1/app-conversations/scan-conv-123/file?file_path=%2Fworkspace%2Ftrivy-results.json',
         expect.objectContaining({
           method: 'GET',
-        })
-      );
-    });
-
-    it('resumes a paused sandbox before downloading Trivy results', async () => {
-      const trivyOutput = {
-        SchemaVersion: 2,
-        Results: [
-          {
-            Target: 'package-lock.json',
-            Vulnerabilities: [],
-          },
-        ],
-      };
-
-      mockFetch
-        .mockResolvedValueOnce(createStreamingResponse('scan-conv-456'))
-        .mockResolvedValueOnce(createJsonResponse([{
-          id: 'scan-conv-456',
-          execution_status: 'finished',
-          sandbox_status: 'PAUSED',
-          sandbox_id: 'sandbox-456',
-        }]))
-        .mockResolvedValueOnce(createJsonResponse({
-          items: [],
-          next_page_id: null,
-        }))
-        .mockResolvedValueOnce(createJsonResponse([{
-          id: 'scan-conv-456',
-          execution_status: 'finished',
-          sandbox_status: 'PAUSED',
-          sandbox_id: 'sandbox-456',
-        }]))
-        .mockResolvedValueOnce(createJsonResponse({ success: true }))
-        .mockResolvedValueOnce(createJsonResponse([{
-          id: 'scan-conv-456',
-          execution_status: 'finished',
-          sandbox_status: 'RUNNING',
-          sandbox_id: 'sandbox-456',
-        }]))
-        .mockResolvedValueOnce(createJsonResponse(JSON.stringify(trivyOutput)));
-
-      const result = await client.scanRepository('https://github.com/test/repo');
-
-      expect(result).toEqual(trivyOutput);
-      expect(mockFetch).toHaveBeenNthCalledWith(
-        5,
-        'http://localhost:3000/api/cloud/v1/sandboxes/sandbox-456/resume',
-        expect.objectContaining({
-          method: 'POST',
         })
       );
     });

--- a/src/test/openhandsCloudClient.test.ts
+++ b/src/test/openhandsCloudClient.test.ts
@@ -33,6 +33,7 @@ function createStreamingResponse(conversationId: string, tasks: object[] = []) {
               value: new TextEncoder().encode(responseBody) 
             });
           },
+          releaseLock: () => undefined,
         };
       },
     },
@@ -42,7 +43,7 @@ function createStreamingResponse(conversationId: string, tasks: object[] = []) {
 /**
  * Helper to create a standard JSON API response mock
  */
-function createJsonResponse(data: object) {
+function createJsonResponse<T>(data: T) {
   return {
     ok: true,
     text: () => Promise.resolve(JSON.stringify(data)),
@@ -407,6 +408,117 @@ describe('OpenHandsClient', () => {
         // Verify the scanRepository was at least attempted
         expect(mockFetch).toHaveBeenCalled();
       }
+    });
+  });
+
+  describe('scanRepository result retrieval', () => {
+    it('falls back to the workspace root Trivy results file when the project path is empty', async () => {
+      const trivyOutput = {
+        SchemaVersion: 2,
+        Results: [
+          {
+            Target: 'package-lock.json',
+            Vulnerabilities: [
+              {
+                VulnerabilityID: 'CVE-2026-1234',
+                PkgName: 'example-package',
+                InstalledVersion: '1.0.0',
+                FixedVersion: '1.0.1',
+                Severity: 'HIGH',
+                Title: 'Example vulnerability',
+              },
+            ],
+          },
+        ],
+      };
+
+      mockFetch
+        .mockResolvedValueOnce(createStreamingResponse('scan-conv-123'))
+        .mockResolvedValueOnce(createJsonResponse([{
+          id: 'scan-conv-123',
+          execution_status: 'finished',
+          sandbox_status: 'RUNNING',
+        }]))
+        .mockResolvedValueOnce(createJsonResponse({
+          items: [],
+          next_page_id: null,
+        }))
+        .mockResolvedValueOnce(createJsonResponse([{
+          id: 'scan-conv-123',
+          execution_status: 'finished',
+          sandbox_status: 'RUNNING',
+          sandbox_id: 'sandbox-123',
+        }]))
+        .mockResolvedValueOnce(createJsonResponse(''))
+        .mockResolvedValueOnce(createJsonResponse(JSON.stringify(trivyOutput)));
+
+      const result = await client.scanRepository('https://github.com/test/repo');
+
+      expect(result).toEqual(trivyOutput);
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        5,
+        'http://localhost:3000/api/cloud/v1/app-conversations/scan-conv-123/file?file_path=%2Fworkspace%2Fproject%2Ftrivy-results.json',
+        expect.objectContaining({
+          method: 'GET',
+        })
+      );
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        6,
+        'http://localhost:3000/api/cloud/v1/app-conversations/scan-conv-123/file?file_path=%2Fworkspace%2Ftrivy-results.json',
+        expect.objectContaining({
+          method: 'GET',
+        })
+      );
+    });
+
+    it('resumes a paused sandbox before downloading Trivy results', async () => {
+      const trivyOutput = {
+        SchemaVersion: 2,
+        Results: [
+          {
+            Target: 'package-lock.json',
+            Vulnerabilities: [],
+          },
+        ],
+      };
+
+      mockFetch
+        .mockResolvedValueOnce(createStreamingResponse('scan-conv-456'))
+        .mockResolvedValueOnce(createJsonResponse([{
+          id: 'scan-conv-456',
+          execution_status: 'finished',
+          sandbox_status: 'PAUSED',
+          sandbox_id: 'sandbox-456',
+        }]))
+        .mockResolvedValueOnce(createJsonResponse({
+          items: [],
+          next_page_id: null,
+        }))
+        .mockResolvedValueOnce(createJsonResponse([{
+          id: 'scan-conv-456',
+          execution_status: 'finished',
+          sandbox_status: 'PAUSED',
+          sandbox_id: 'sandbox-456',
+        }]))
+        .mockResolvedValueOnce(createJsonResponse({ success: true }))
+        .mockResolvedValueOnce(createJsonResponse([{
+          id: 'scan-conv-456',
+          execution_status: 'finished',
+          sandbox_status: 'RUNNING',
+          sandbox_id: 'sandbox-456',
+        }]))
+        .mockResolvedValueOnce(createJsonResponse(JSON.stringify(trivyOutput)));
+
+      const result = await client.scanRepository('https://github.com/test/repo');
+
+      expect(result).toEqual(trivyOutput);
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        5,
+        'http://localhost:3000/api/cloud/v1/sandboxes/sandbox-456/resume',
+        expect.objectContaining({
+          method: 'POST',
+        })
+      );
     });
   });
 });

--- a/src/test/testConnectionApi.test.ts
+++ b/src/test/testConnectionApi.test.ts
@@ -1,7 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
+import ts from 'typescript';
 import handler from '../../api/test-connection';
 import { getOpenHandsCloudAuthCheckUrl } from '@/lib/openhandsCloudApi';
 
+const execFileAsync = promisify(execFile);
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
@@ -15,6 +23,27 @@ function createResponseMock() {
   res.json.mockReturnValue(res);
 
   return res;
+}
+
+async function transpileIntoTempDir(relativePath: string, tempDir: string): Promise<string> {
+  const sourcePath = path.resolve(process.cwd(), relativePath);
+  const source = await readFile(sourcePath, 'utf8');
+  const outputPath = path.join(tempDir, relativePath.replace(/\.ts$/, '.js'));
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      esModuleInterop: true,
+      skipLibCheck: true,
+    },
+    fileName: sourcePath,
+  });
+
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, transpiled.outputText, 'utf8');
+
+  return outputPath;
 }
 
 describe('api/test-connection', () => {
@@ -49,5 +78,32 @@ describe('api/test-connection', () => {
     );
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ success: true, message: 'Connected successfully' });
+  });
+
+  it('stays importable after ESM transpilation for the serverless runtime', async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'test-connection-esm-'));
+
+    try {
+      await writeFile(
+        path.join(tempDir, 'package.json'),
+        JSON.stringify({ type: 'module' }),
+        'utf8'
+      );
+
+      const entryPath = await transpileIntoTempDir('api/test-connection.ts', tempDir);
+      await transpileIntoTempDir('src/lib/openhandsCloudApi.ts', tempDir);
+
+      await expect(
+        execFileAsync(process.execPath, [
+          '--input-type=module',
+          '-e',
+          `await import(${JSON.stringify(pathToFileURL(entryPath).href)});`,
+        ])
+      ).resolves.toMatchObject({
+        stderr: '',
+      });
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- fix the Vercel serverless `/api/test-connection` ESM import by using the emitted `.js` path for `src/lib/openhandsCloudApi`
- keep Trivy result lookup resilient by checking both `/workspace/project/trivy-results.json` and `/workspace/trivy-results.json`
- handle OpenHands file download responses that arrive as raw text or JSON-string payloads so Trivy results parse correctly
- add regression coverage for the serverless ESM runtime path and the cloud file-download response shapes

## Verification
- `npm test`
- `npm run build`

## Notes
- `npm run lint` still fails on the existing repo-wide warning baseline (`242` warnings)
- latest branch preview URL: https://openhands-vulnerability-fixer-git-aivong-openh-acfa3a-openhands.vercel.app
